### PR TITLE
Make the logic to find libclang in sip_generator.py match that in FindPythonModuleGeneration.cmake.

### DIFF
--- a/find-modules/sip_generation/sip_generator.py
+++ b/find-modules/sip_generation/sip_generator.py
@@ -953,7 +953,7 @@ class SipGenerator(object):
             lines = subprocess.check_output(["/sbin/ldconfig", "-p"])
             for line in lines.split("\n"):
                 fields = line.split()
-                if fields and fields[0].startswith("libclang.so"):
+                if fields and re.match("libclang.*\.so", fields[0]):
                     SipGenerator._libclang = fields[-1]
                     logger.debug(_("Found libclang at {}").format(SipGenerator._libclang))
         if SipGenerator._libclang:


### PR DESCRIPTION
Without this change, the naming convention on current Ubuntu don't result in a match:

$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 16.10
Release:        16.10
Codename:       yakkety
$ ldconfig -p | grep libclang.*.so 
        libclang-3.9.so.1 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libclang-3.9.so.1
        libclang-3.9.so (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libclang-3.9.so
